### PR TITLE
NVIdb v0.5.4

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: NVIdb
 Title: Facilitating use of Norwegian Veterinary Institute's databases
-Version: 0.5.3
-Date: 2021-05-07
+Version: 0.5.4
+Date: 2021-05-10
 Authors@R: 
   c(person(given = "Petter",
            family = "Hopp",

--- a/NEWS
+++ b/NEWS
@@ -1,3 +1,11 @@
+NVIdb 0.5.4 - (2021-05-10)
+--------------------------
+
+Bug fixes:
+
+- standardize_columns now accepts arguments for property written with both lower and upper case.
+
+
 NVIdb 0.5.3 - (2021-05-07)
 --------------------------
 

--- a/R/add_kommune_fylke.R
+++ b/R/add_kommune_fylke.R
@@ -118,13 +118,13 @@ add_kommune_fylke <- function(data,
     # For fylkenr, select the fylke where most kommuner is within the fylke. This to avoid fylkenr to be translated to fylker
     # where one or a few kommuner has been relocated.
     code_2_new <- code_2_new %>%
-      poorman::rename(antall = komnr) %>%
-      poorman::distinct() %>%
-      poorman::group_by(fylkenr) %>%
-      poorman::mutate(maxantall = max(antall)) %>%
-      poorman::ungroup() %>%
-      poorman::filter(maxantall == antall) %>%
-      poorman::select(-antall, -maxantall)
+      dplyr::rename(antall = komnr) %>%
+      dplyr::distinct() %>%
+      dplyr::group_by(fylkenr) %>%
+      dplyr::mutate(maxantall = max(antall)) %>%
+      dplyr::ungroup() %>%
+      dplyr::filter(maxantall == antall) %>%
+      dplyr::select(-antall, -maxantall)
 
   }
 

--- a/R/standardize_columns.R
+++ b/R/standardize_columns.R
@@ -106,6 +106,8 @@ standardize_columns <- function(data,
   # Report check-results
   checkmate::reportAssertions(checks)
 
+  property <- tolower(property)
+  
   # # Error handling
   # # 1. property is not given
   # property <- tolower(property)
@@ -328,7 +330,7 @@ standardize_columns <- function(data,
     # New column with standard column names¨
     colwidths <- merge(colwidths, standard, by.x = "V1", by.y = "colname", all.x = TRUE)
     # Impute with snake case of column name in case standard column name isn't defined
-    colwidths[which(is.na(colwidths$colwidth)), "colwidth"] <- 10.78
+    colwidths[which(is.na(colwidths$colwidth)), "colwidth"] <- 10.71
 
     # Sorts data in original order
     colwidths <- colwidths[order(colwidths$original_sort_order), ]

--- a/tests/testthat/test_standardize_columns.R
+++ b/tests/testthat/test_standardize_columns.R
@@ -108,41 +108,49 @@ test_that("colClasses for csv-files", {
 })
 
 
-# test_that("Standardize colwidths for Excel", {
-#   # Generate data frame with column names for table that should be exported to Excel
-#   # Example with selection of samples collected in herds
-#   df <- cbind("aar" = "2021", "rapport" = "Brucellose hos geit, utvalgsliste",
-#               "mt_regionnr" = "M22000", "mt_region" = " Region Øst ",
-#               "mt_avdelingnr" = " M22110", "mt_avdeling" = " Glåmdal og Østerdal ",
-#               "eier_lokalitetnr" = "34343434", "eier_lokalitet" = "Gårdsbruk", "postnr" = "2560", "poststed" = " ALVDAL ",
-#               "ant_prover" = 30)
-#
+test_that("Standardize colwidths for Excel", {
+# skip if no connection to 'FAG' have been established
+skip_if_not(dir.exists(set_dir_NVI("FAG")))
+
+PJStest <- readRDS(file.path(".", "PJS_testdata.rds"))
+# PJStest <- readRDS("./tests/testthat/PJS_testdata.rds")
+
 #   # Make a vector with correct column names after translation
-#   correct_result <- c(5, 10.78, 12.5, 16, 13, 33, 12, 30, 8, 15, 8.5)
-#
-#   # Compare Add fylke, current fylkenr and current fylke with correct result
-#   expect_equal(standardize_columns(data = df, dbsource = "geit_brucella_utvalg",
-#                                                 property = "colwidths_Excel"),
-#                    correct_result)
-#
-#   # Generate data frame with column names for table that should be exported to Excel
-#   # Example with selection of samples collected at slaughterhouses
-#   df <- cbind("mt_regionnr" = "M25000", "mt_region" = "Region Nord",
-#               "mt_avdelingnr" = "M25150", "mt_avdeling" = "Finnmark",
-#               "eier_lokalitetnr" = "802", "eier_lokalitet" = "NORTURA SA AVD. FINNMARK/KARASJOK",
-#               "ant_prover" = 30)
-#
-#
-#   # Make a vector with correct column names after translation
-#   correct_result <- c(12.5, 16, 13, 33, 7, 35, 8.5)
-#
-#   # Compare Add fylke, current fylkenr and current fylke with correct result
-#   expect_identical(standardize_columns(data = df, dbsource = "sau_brucella_slakteri",
-#                                                 property = "colwidths_Excel"),
-#                    correct_result)
-#
-# })
-#
+correct_result <- c(5.00, 10.71, 10.71, 10.71, 10.71, 10.71, 10.71, 10.00, 10.71, 10.71,
+                    10.71, 10.71, 10.71, 10.71, 10.71, 10.71, 10.71, 10.71, 10.71, 10.71,
+                    10.71, 10.71, 10.71, 10.71, 10.71, 10.71, 10.71, 10.71, 10.71, 10.71,
+                    10.71, 11.00, 11.00, 10.71, 10.71, 10.71, 10.71, 10.71, 10.71, 10.71,
+                    10.71, 10.71, 10.71, 11.00, 10.71, 8.00, 10.71, 10.71, 10.71, 10.71,
+                    10.71, 10.71, 10.71, 10.71, 11.00, 10.71, 10.71, 10.71, 10.71, 10.71,
+                    10.71, 10.71, 10.71, 10.71, 10.71, 10.71, 10.71, 10.71, 10.71, 10.71,
+                    10.71, 10.71, 10.71, 10.71, 10.71, 10.71, 10.71, 10.71, 10.71, 10.71,
+                    10.71, 10.71, 10.71, 10.71, 10.71, 10.71, 10.71, 10.71, 10.71, 10.71,
+                    10.71, 10.71, 10.71, 10.71, 10.71)
+
+  expect_equal(standardize_columns(data = PJStest, property = "colwidths_Excel"),
+                   correct_result)
+
+  
+  # Standardisere kolonnenavn
+  PJStest <- standardize_columns(data = PJStest, property = "colnames")
+  
+  #   # Make a vector with correct column names after translation
+  correct_result <- c(5.00, 10.71, 10.71, 10.71, 10.71, 10.71, 10.00, 10.00, 10.00, 10.00,
+                      10.00, 10.71, 10.71, 5.00, 10.71, 10.71, 10.71, 10.71, 10.71, 10.71,
+                      10.71, 10.71, 10.71, 10.71, 10.71, 10.71, 10.71, 10.71, 10.71, 10.71,
+                      5.00, 11.00, 11.00, 10.71, 10.71, 10.71, 10.71, 10.71, 10.71, 10.71,
+                      10.71, 10.00, 10.00, 11.00, 10.71, 8.00, 10.71, 10.71, 10.71, 10.71,
+                      10.71, 10.71, 10.71, 10.71, 11.00, 10.71, 10.71, 10.71, 10.71, 10.71,
+                      10.71, 10.71, 10.71, 10.71, 10.71, 10.71, 10.71, 10.71, 10.71, 10.71,
+                      10.71, 10.71, 10.71, 10.71, 10.71, 10.71, 10.71, 10.71, 10.71, 10.71,
+                      8.00, 10.00, 10.71, 10.71, 10.71, 10.71, 10.71, 10.71, 10.71, 10.71,
+                      10.71, 10.71, 10.71, 10.71, 10.71)
+  
+  expect_equal(standardize_columns(data = PJStest, property = "colwidths_Excel"),
+               correct_result)
+  
+})
+
 
 test_that("Standardize English collabels", {
 


### PR DESCRIPTION
fix: standardize columns now accepts arguments for property in both lower and upper case.