### PR TITLE
feat: improved standardize columns

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: NVIdb
 Title: Tools to facilitate the use of NVI's databases
-Version: 0.13.0
-Date: 2024-12-13
+Version: 0.13.0.9000
+Date: 2024-##-##
 Authors@R: 
   c(person(given = "Petter",
            family = "Hopp",

--- a/NEWS.md
+++ b/NEWS.md
@@ -2,7 +2,7 @@
 
 ## New features:
 
--
+- `standardize_columns` now accepts list or filename and path as input to `standards`.
 
 
 ## Bug fixes:

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,25 @@
+# NVIdb 0.13.0.9000 - (2024-##-##)
+
+## New features:
+
+-
+
+
+## Bug fixes:
+
+-
+
+
+## Other changes:
+
+-
+
+
+## BREAKING CHANGES:
+
+-
+
+
 # NVIdb 0.13.0 - (2024-12-13)
 
 ## Bug fixes:

--- a/R/standardize_columns.R
+++ b/R/standardize_columns.R
@@ -23,11 +23,11 @@
 #'     giving the standards when generating
 #'     selection files for the Norwegian surveillance programmes. As this file
 #'     is embedded into OKplan-package, it may be convenient to update the
-#'     source file and load it as a csv file. On some occations, it may be most
-#'     easy to input the column standards directly using a list.
+#'     source file and load it as a csv file. On some occasions, it may be most
+#'     easy to input the column standards directly using a \code{list}.
 #'
 #'     #' The list input to column_standards must follow a specific format.
-#'     It is a list with at least three named vectors:
+#'     It is a \code{list} with at least three named vectors:
 #' \itemize{
 #' \item \code{colname}: a vector of all columns in in the source file that
 #'     should be included in the Excel report with the selection list.
@@ -43,10 +43,10 @@
 #' \item \code{colorder}: the order of the columns to be used in the Excel report.
 #'     The default is to use the same order as they are entered in the vectors.
 #' \item \code{column_db}: input added as a possibility to keep on the same format
-#'     as \ifelse{html}{\code{\link{column_standards}}}. 
+#'     as \ifelse{html}{\code{\link{column_standards}}}.
 #'     Not necessary to input.
 #' \item \code{table_db}: input added as a possibility to keep on the same format
-#'     as \ifelse{html}{\code{\link{column_standards}}}. 
+#'     as \ifelse{html}{\code{\link{column_standards}}}.
 #'     Must be the same as
 #'     \code{dbsource}. Not necessary to input.
 #' }
@@ -116,10 +116,10 @@
 #'     the data source as registered in column_standards table. Defaults
 #'     to \code{deparse(substitute(data))}.
 #' @param standards [\code{data.frame} | \code{list} | \code{character(1)}]\cr
-#' For giving alternative standard tables to column_standards. See details.
-#'     Defaults to
+#' For giving alternatives to the standard table for column_standards using
+#'     different formats, see details. Defaults to
 #'     file.path(NVIdb::set_dir_NVI("ProgrammeringR", slash = FALSE),
-#'               "standardization", "colnames", "column_standards.csv")
+#'               "standardization", "colnames", "column_standards.csv").
 #' @param property [\code{character(1)}]\cr
 #' Property of the column that should be standardized. Must be one
 #'     of c("colnames", "colclasses", "collabels", "colwidths_Excel",

--- a/man/standardize_columns.Rd
+++ b/man/standardize_columns.Rd
@@ -7,7 +7,8 @@
 standardize_columns(
   data,
   dbsource = deparse(substitute(data)),
-  standards = NULL,
+  standards = file.path(NVIdb::set_dir_NVI("ProgrammeringR", slash = FALSE),
+    "standardization", "colnames", "column_standards.csv"),
   property,
   language = "no",
   exclude = FALSE,
@@ -24,8 +25,11 @@ The database that is the source of data. Should be the name of
     the data source as registered in column_standards table. Defaults
     to \code{deparse(substitute(data))}.}
 
-\item{standards}{[\code{character(1)}]\cr
-For giving alternative standard tables to column_standards.}
+\item{standards}{[\code{data.frame} | \code{list} | \code{character(1)}]\cr
+For giving alternative standard tables to column_standards. See details.
+    Defaults to
+    file.path(NVIdb::set_dir_NVI("ProgrammeringR", slash = FALSE),
+              "standardization", "colnames", "column_standards.csv")}
 
 \item{property}{[\code{character(1)}]\cr
 Property of the column that should be standardized. Must be one
@@ -65,7 +69,7 @@ Standardizes column names, labels, column width
     for variables in external databases.
 }
 \details{
-The standardization table is under development. This
+The standardisation table is under development. This
     function only works when being connected to the NVI network.
 
 Variables in internal and external data sources uses
@@ -78,6 +82,41 @@ Variables in internal and external data sources uses
     and
     \ifelse{html}{\code{\link[data.table:fread]{data.table::fread}}}{\code{data.table::fread}}
     can be generated.
+
+\code{standards} gives the source file or the data.frame with the standards
+    for formatting the columns. Default is to give the general source csv
+    file. It can also be a data.frame as for example the
+    \ifelse{html}{\code{\link[OKplan:OK_column_standards]{OKplan::OK_column_standards}}}{\code{OKplan::OK_column_standards}}
+    giving the standards when generating
+    selection files for the Norwegian surveillance programmes. As this file
+    is embedded into OKplan-package, it may be convenient to update the
+    source file and load it as a csv file. On some occations, it may be most
+    easy to input the column standards directly using a list.
+
+    #' The list input to column_standards must follow a specific format.
+    It is a list with at least three named vectors:
+\itemize{
+\item \code{colname}: a vector of all columns in in the source file that
+    should be included in the Excel report with the selection list.
+\item \code{collabel}: A vector with the labels that should be used in the
+    Excel report.
+\item \code{colwidth}: A vector with the column width that should be used
+    in the Excel report.
+}
+
+    In addition one may input:
+
+\itemize{
+\item \code{colorder}: the order of the columns to be used in the Excel report.
+    The default is to use the same order as they are entered in the vectors.
+\item \code{column_db}: input added as a possibility to keep on the same format
+    as \code{\link{OK_column_standards}}. Not necessary to input.
+\item \code{table_db}: input added as a possibility to keep on the same format
+    as \code{\link{OK_column_standards}}. Must be the same as
+    \code{dbsource}. Not necessary to input.
+}
+
+All vectors must have the same order and the same length.
 
 \code{property = "colnames"} will replace the column names
     in a data frame with standardized column names. All

--- a/man/standardize_columns.Rd
+++ b/man/standardize_columns.Rd
@@ -26,10 +26,10 @@ The database that is the source of data. Should be the name of
     to \code{deparse(substitute(data))}.}
 
 \item{standards}{[\code{data.frame} | \code{list} | \code{character(1)}]\cr
-For giving alternative standard tables to column_standards. See details.
-    Defaults to
+For giving alternatives to the standard table for column_standards using
+    different formats, see details. Defaults to
     file.path(NVIdb::set_dir_NVI("ProgrammeringR", slash = FALSE),
-              "standardization", "colnames", "column_standards.csv")}
+              "standardization", "colnames", "column_standards.csv").}
 
 \item{property}{[\code{character(1)}]\cr
 Property of the column that should be standardized. Must be one
@@ -90,11 +90,11 @@ Variables in internal and external data sources uses
     giving the standards when generating
     selection files for the Norwegian surveillance programmes. As this file
     is embedded into OKplan-package, it may be convenient to update the
-    source file and load it as a csv file. On some occations, it may be most
-    easy to input the column standards directly using a list.
+    source file and load it as a csv file. On some occasions, it may be most
+    easy to input the column standards directly using a \code{list}.
 
     #' The list input to column_standards must follow a specific format.
-    It is a list with at least three named vectors:
+    It is a \code{list} with at least three named vectors:
 \itemize{
 \item \code{colname}: a vector of all columns in in the source file that
     should be included in the Excel report with the selection list.
@@ -110,9 +110,11 @@ Variables in internal and external data sources uses
 \item \code{colorder}: the order of the columns to be used in the Excel report.
     The default is to use the same order as they are entered in the vectors.
 \item \code{column_db}: input added as a possibility to keep on the same format
-    as \code{\link{OK_column_standards}}. Not necessary to input.
+    as \ifelse{html}{\code{\link{column_standards}}}.
+    Not necessary to input.
 \item \code{table_db}: input added as a possibility to keep on the same format
-    as \code{\link{OK_column_standards}}. Must be the same as
+    as \ifelse{html}{\code{\link{column_standards}}}.
+    Must be the same as
     \code{dbsource}. Not necessary to input.
 }
 

--- a/tests/testthat/test_login.R
+++ b/tests/testthat/test_login.R
@@ -7,7 +7,7 @@ test_that("Log in to db services", {
 
   linewidth <- options("width")
   options(width = 80)
-  
+
   odbc_connected <- login("PJS")
   expect_true(as.vector(odbc_connected) >= 1)
   RODBC::odbcClose(odbc_connected)
@@ -21,7 +21,7 @@ test_that("Log in to db services", {
                                 regexp = "'login_by_credentials_PJS' is replaced by 'login_by_credentials")
   expect_true(as.vector(odbc_connected) >= 1)
   RODBC::odbcClose(odbc_connected)
-  
+
   options(width = unlist(linewidth))
 })
 
@@ -49,4 +49,3 @@ test_that("Errors or warnings for login", {
 
   options(width = unlist(linewidth))
 })
-

--- a/tests/testthat/test_standardize_columns.R
+++ b/tests/testthat/test_standardize_columns.R
@@ -32,6 +32,13 @@ test_that("Standardize colnames from PJS", {
                                                 property = "colnames")),
                    correct_result)
 
+  # Compare Add fylke, current fylkenr and current fylke with correct result
+  expect_identical(colnames(standardize_columns(data = df,
+                                                standards = file.path(NVIdb::set_dir_NVI("ProgrammeringR", slash = FALSE),
+                                                                      "standardization", "colnames", "column_standards.csv"),
+                                                property = "colnames")),
+                   correct_result)
+
 })
 
 
@@ -58,6 +65,14 @@ test_that("Standardize colnames from EOS scrapie", {
   # Compare Add fylke, current fylkenr and current fylke with correct result
   expect_identical(colnames(standardize_columns(data = df,
                                                 dbsource = "proveresultat_scrapie",
+                                                property = "colnames")),
+                   correct_result)
+
+  # Compare Add fylke, current fylkenr and current fylke with correct result
+  expect_identical(colnames(standardize_columns(data = df,
+                                                dbsource = "proveresultat_scrapie",
+                                                standards = file.path(NVIdb::set_dir_NVI("ProgrammeringR", slash = FALSE),
+                                                                      "standardization", "colnames", "column_standards.csv"),
                                                 property = "colnames")),
                    correct_result)
 
@@ -108,26 +123,26 @@ test_that("colClasses for csv-files", {
 
 
 test_that("Standardize colwidths for Excel", {
-# skip if no connection to 'FAG' have been established
-skip_if_not(dir.exists(set_dir_NVI("FAG")))
+  # skip if no connection to 'FAG' have been established
+  skip_if_not(dir.exists(set_dir_NVI("FAG")))
 
-PJStest <- readRDS(file.path(".", "PJS_testdata.rds"))
-# PJStest <- readRDS("./tests/testthat/PJS_testdata.rds")
+  PJStest <- readRDS(file.path(".", "PJS_testdata.rds"))
+  # PJStest <- readRDS("./tests/testthat/PJS_testdata.rds")
 
-#   # Make a vector with correct column names after translation
-correct_result <- c(5.00, 10.71, 10.71, 10.71, 10.71, 10.71, 10.71, 10.00, 10.71, 10.71,
-                    10.71, 10.71, 10.71, 10.71, 10.71, 10.71, 10.71, 10.71, 10.71, 10.71,
-                    10.71, 10.71, 10.71, 20.00, 20.00, 10.71, 10.71, 10.71, 10.71, 10.71,
-                    10.71, 11.00, 11.00, 10.71, 10.71, 10.71, 10.71, 10.71, 10.71, 10.71,
-                    10.71, 10.71, 10.71, 11.00, 10.71,  8.00, 10.71, 10.71, 10.71, 10.71,
-                    30.00, 10.71, 10.71, 10.71, 11.00, 10.71, 10.71, 10.71, 10.71, 10.71,
-                    10.71, 10.71, 10.71, 10.71, 10.71, 10.71, 10.71, 10.71, 10.71, 10.71,
-                    10.71, 10.71, 10.71, 10.71, 10.71, 10.71, 10.71, 10.71, 10.71, 10.71,
-                    10.71, 10.71, 10.71, 10.71, 10.71, 10.71, 10.71, 10.71, 10.71, 10.71,
-                    10.71, 10.71, 10.71, 10.71, 8.00)
+  #   # Make a vector with correct column names after translation
+  correct_result <- c(5.00, 10.71, 10.71, 10.71, 10.71, 10.71, 10.71, 10.00, 10.71, 10.71,
+                      10.71, 10.71, 10.71, 10.71, 10.71, 10.71, 10.71, 10.71, 10.71, 10.71,
+                      10.71, 10.71, 10.71, 20.00, 20.00, 10.71, 10.71, 10.71, 10.71, 10.71,
+                      10.71, 11.00, 11.00, 10.71, 10.71, 10.71, 10.71, 10.71, 10.71, 10.71,
+                      10.71, 10.71, 10.71, 11.00, 10.71,  8.00, 10.71, 10.71, 10.71, 10.71,
+                      30.00, 10.71, 10.71, 10.71, 11.00, 10.71, 10.71, 10.71, 10.71, 10.71,
+                      10.71, 10.71, 10.71, 10.71, 10.71, 10.71, 10.71, 10.71, 10.71, 10.71,
+                      10.71, 10.71, 10.71, 10.71, 10.71, 10.71, 10.71, 10.71, 10.71, 10.71,
+                      10.71, 10.71, 10.71, 10.71, 10.71, 10.71, 10.71, 10.71, 10.71, 10.71,
+                      10.71, 10.71, 10.71, 10.71, 8.00)
 
   expect_equal(standardize_columns(data = PJStest, property = "colwidths_Excel"),
-                   correct_result)
+               correct_result)
 
 
   # Standardisere kolonnenavn
@@ -137,12 +152,12 @@ correct_result <- c(5.00, 10.71, 10.71, 10.71, 10.71, 10.71, 10.71, 10.00, 10.71
   correct_result <- c(5.00, 10.71, 10.71, 10.71, 10.71, 10.71, 10.00, 10.00, 10.00, 10.00,
                       10.00, 10.71, 10.71, 5.00, 10.71, 10.71, 10.71, 10.71, 10.71, 10.71,
                       10.71, 10.71, 10.71, 20.00, 20.00, 10.71, 10.71, 10.71, 10.71, 10.71,
-                       5.00, 11.00, 11.00, 10.71, 10.71, 10.71, 10.71, 10.71, 10.71, 10.71,
+                      5.00, 11.00, 11.00, 10.71, 10.71, 10.71, 10.71, 10.71, 10.71, 10.71,
                       10.71, 10.00, 10.00, 11.00, 10.71, 8.00, 10.71, 10.71, 10.71, 10.71,
                       30.00, 10.71, 10.71, 10.71, 11.00, 10.71, 10.71, 10.71, 10.71, 10.71,
                       10.71, 10.71, 10.71, 10.71, 10.71, 10.71, 10.71, 10.71, 10.71, 10.71,
                       10.71, 10.71, 10.71, 10.71, 10.71, 10.71, 10.71, 10.71, 10.71, 10.71,
-                       8.00, 10.00, 10.71, 10.71, 10.71, 10.71, 10.71, 10.71, 10.71, 10.71,
+                      8.00, 10.00, 10.71, 10.71, 10.71, 10.71, 10.71, 10.71, 10.71, 10.71,
                       10.71, 10.71, 10.71, 30.00, 8.00)
 
   expect_equal(standardize_columns(data = PJStest, property = "colwidths_Excel"),
@@ -155,12 +170,12 @@ correct_result <- c(5.00, 10.71, 10.71, 10.71, 10.71, 10.71, 10.71, 10.00, 10.71
   correct_result <- c(5.00, 10.71, 10.71, 10.71, 10.71, 10.71, 10.00, 10.00, 10.00, 10.00,
                       10.00, 10.71, 10.71, 5.00, 10.71, 10.71, 10.71, 10.71, 10.71, 10.71,
                       10.71, 10.71, 10.71, 20.00, 20.00, 10.71, 10.71, 10.71, 10.71, 10.71,
-                       5.00, 11.00, 11.00, 10.71, 10.71, 10.71, 10.71, 10.71, 10.71, 10.71,
+                      5.00, 11.00, 11.00, 10.71, 10.71, 10.71, 10.71, 10.71, 10.71, 10.71,
                       10.71, 10.00, 10.00, 11.00, 10.71, 8.00, 10.71, 10.71, 10.71, 10.71,
                       30.00, 10.71, 10.71, 10.71, 11.00, 10.71, 10.71, 10.71, 10.71, 10.71,
                       10.71, 10.71, 10.71, 10.71, 10.71, 10.71, 10.71, 10.71, 10.71, 10.71,
                       10.71, 10.71, 10.71, 10.71, 10.71, 10.71, 10.71, 10.71, 10.71, 10.71,
-                       8.00, 10.00, 10.71, 10.71, 10.71, 10.71, 10.71, 10.71, 10.71, 10.71,
+                      8.00, 10.00, 10.71, 10.71, 10.71, 10.71, 10.71, 10.71, 10.71, 10.71,
                       10.71, 10.71, 10.71, 30.00, 8.00)
 
   expect_equal(standardize_columns(data = PJStest, property = "colwidths_Excel"),
@@ -186,6 +201,13 @@ test_that("Standardize English collabels", {
 
   # Compare Add fylke, current fylkenr and current fylke with correct result
   expect_identical(standardize_columns(data = df,
+                                       property = "collabels",
+                                       language = "en"),
+                   correct_result)
+
+  expect_identical(standardize_columns(data = df,
+                                       standards = file.path(NVIdb::set_dir_NVI("ProgrammeringR", slash = FALSE),
+                                                             "standardization", "colnames", "column_standards.csv"),
                                        property = "collabels",
                                        language = "en"),
                    correct_result)
@@ -228,7 +250,54 @@ test_that("Column order", {
 })
 
 
+test_that("List input to standards", {
+  # Make example data
+  df <- as.data.frame(cbind("ok_aar" = 2021, "rapport" = "Brucellose hos geit, utvalgsliste",
+                            "mt_avdelingnr" = "M21150", "mt_avdeling" = "Romerike",
+                            "mt_regionnr" = "M21000", "mt_region" = "Region Stor-Oslo",
+                            "eier_lokalitetnr" = "30303030", "eier_lokalitet" = "XXX XXXXX", "orgnr" = 989989989,
+                            "postnr" = "0468", "poststed" = "OSLO", "ant_prover" = 26))
+  # Probably first makes a matrix, therefore "Antall prøver" is character.
+  df$ant_prover <- as.numeric(df$ant_prover)
+
+  df <- standardize_columns(data = df,
+                            standards =
+                              list("colname" = c("ok_aar", "rapport", "mt_regionnr", "mt_region", "mt_avdelingnr",
+                                                 "mt_avdeling", "eier_lokalitetnr", "orgnr", "eier_lokalitet", "postnr", "poststed",
+                                                 "ant_prover"),
+                                   "collabel" = c("År", "Rapport", "MT regionnr", "MT region", "MT avdelingsnr",
+                                                  "MT avdeling", "Produsentnr", "Virksomhetnr", "Virksomhet", "Postnr", "Poststed",
+                                                  "Antall prøver"),
+                                   "colwidth" = c(5, 9, 12.5, 16, 13, 30, 12, 12, 30, 8, 15, 8.5)),
+                            dbsource = "brucella_geit",
+                            property = "colorder",
+                            exclude = TRUE)
+
+  expect_equal(colnames(df),
+               c("ok_aar", "rapport", "mt_regionnr", "mt_region", "mt_avdelingnr", "mt_avdeling", "eier_lokalitetnr", "orgnr",
+                  "eier_lokalitet", "postnr", "poststed", "ant_prover"))
+
+  expect_equal(standardize_columns(data = df,
+                            standards =
+                              list("colname" = c("ok_aar", "rapport", "mt_regionnr", "mt_region", "mt_avdelingnr",
+                                                 "mt_avdeling", "eier_lokalitetnr", "orgnr", "eier_lokalitet", "postnr", "poststed",
+                                                 "ant_prover"),
+                                   "collabel" = c("År", "Rapport", "MT regionnr", "MT region", "MT avdelingsnr",
+                                                  "MT avdeling", "Produsentnr", "Virksomhetnr", "Virksomhet", "Postnr", "Poststed",
+                                                  "Antall prøver"),
+                                   "colwidth" = c(5, 9, 12.5, 16, 13, 30, 12, 12, 30, 8, 15, 8.5)),
+                            dbsource = "brucella_geit",
+                            property = "collabels",
+                            exclude = TRUE),
+               c("År", "Rapport",
+                 "MT regionnr", "MT region", "MT avdelingsnr", "MT avdeling",
+                 "Produsentnr", "Virksomhetnr", "Virksomhet",
+                 "Postnr", "Poststed", "Antall prøver"))
+})
+
 test_that("standardize_columns argument checking", {
+  linewidth <- options("width")
+  options(width = 80)
 
   PJStest <- readRDS(file.path(".", "PJS_testdata.rds"))
   # PJStest <- readRDS("./tests/testthat/PJS_testdata.rds")
@@ -239,6 +308,9 @@ test_that("standardize_columns argument checking", {
   expect_error(standardize_columns(data = PJStest, property = "columnNames", language = "no", exclude = FALSE),
                regexp = "property")
 
+  expect_error(standardize_columns(data = PJStest, standards = 1, property = "colNames", language = "no", exclude = FALSE),
+               regexp = "but has class 'numeric'")
+
   expect_error(standardize_columns(data = PJStest, property = "colClasses", language = "no", exclude = FALSE),
                regexp = "No file provided.")
 
@@ -248,4 +320,5 @@ test_that("standardize_columns argument checking", {
   expect_error(standardize_columns(data = PJStest, property = "colNames", language = "no", exclude = "FALSE"),
                regexp = "Variable 'exclude': Must be of type 'logical', not 'character'.")
 
+  options(width = unlist(linewidth))
 })


### PR DESCRIPTION
standardize_columns now accepts a filename, a data.frame and a list as input to the argument standards.